### PR TITLE
fix: update .NET SDK version to 9.0.200

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.119",
+    "version": "9.0.200",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
vscodeで以下のエラーとなるため、global.jsonを書き換え、ローカルのmacにインストールされているdotnetを9.0.200以上にバージョンアップしました。

インストールされている .NET SDK が global.json で指定されたバージョンと一致していることを確認してください。